### PR TITLE
Add doc comments explaining some aspects of the IR

### DIFF
--- a/generic/src/simplify.rs
+++ b/generic/src/simplify.rs
@@ -158,68 +158,68 @@ pub fn simplify(design: &mut Design) -> bool {
     design.compact()
 }
 
-// Finds positions within an `adc` cell where the carry chain up to the position
-// doesn't affect output bits past the position, then splits the cell into smaller
-// `adc` cells at these positions.
-//
-// This function recognizes the following cases:
-//
-// 1. `a` and `b` have the same net at position `i`:
-//
-//    ```
-//       { a7 a6 a5 ab4 a3 a2 a1 a0 } +
-//       { b7 b6 b5 ab4 b3 b2 b1 b0 } + ci =
-//    { y8 y7 y6 y5  y4 y3 y2 y1 y0 }
-//    ```
-//
-//    In this case, the carry out of position `i` will always be equal to the value
-//    of the common net.  The sum at that position will be equal to carry out of position
-//    `i - 1` (or to carry input, for position 0).  The above example gets split into two
-//    `adc` cells:
-//
-//    ```
-//    { y8 y7 y6 y5 } =
-//       { a7 a6 a5 } +
-//       { b7 b6 b5 } + ab4
-//
-//    { y4 y3 y2 y1 y0 } =
-//       { a3 a2 a1 a0 } +
-//       { b3 b2 b1 b0 } + ci
-//    ```
-//
-// 2. The low bit of `a` (or `b`) is the same net as the carry input:
-//
-//    ```
-//    { y4 y3 y2 y1 y0 } =
-//       { a3 a2 a1 a0 } +
-//       { b3 b2 b1 b0 } + a0
-//    ```
-//
-//    In this case, The carry out of position `0` will always be equal to `a0`, and the sum
-//    at this position will be equal to `b0`.  The above example gets split up as follows:
-//
-//    ```
-//    { y4 y3 y2 y1 } =
-//       { a3 a2 a1 } +
-//       { b3 b2 b1 } + a0
-//
-//    y0 = b0
-//    ```
-//
-// This optimization is comically general.  We are mostly interested in it for its useful special
-// cases:
-//
-// - `a + a` will get optimized into `{ a 0 }`
-// - `a + a + ci` will get optimized into `{ a ci }`
-// - when both operands have const LSBs, the low part is const-folded
-// - when one operand has const-0 LSBs, and the CI is 0, the low bits of output are replaced with
-//   bits of the other operand
-// - when one operand has const-1 LSBs, and the CI is 1, the low bits of output are replaced with
-//   bits of the other operand
-// - when the two operands have disjoint sets of non-zero positions (eg. `{ a0 a1 0 0 } + { 0 0 b2 b3 }`,
-//   the whole cell is replaced by a buffer
-// - when there's a stretch of zeros in both operands at the same positions, the cell gets split into two `adc`
-// - when both operands have redundant 0 bits at MSBs, the high bits of output are replaced with 0
+/// Finds positions within an `adc` cell where the carry chain up to the position
+/// doesn't affect output bits past the position, then splits the cell into smaller
+/// `adc` cells at these positions.
+///
+/// This function recognizes the following cases:
+///
+/// 1. `a` and `b` have the same net at position `i`:
+///
+///    ```
+///       { a7 a6 a5 ab4 a3 a2 a1 a0 } +
+///       { b7 b6 b5 ab4 b3 b2 b1 b0 } + ci =
+///    { y8 y7 y6 y5  y4 y3 y2 y1 y0 }
+///    ```
+///
+///    In this case, the carry out of position `i` will always be equal to the value
+///    of the common net.  The sum at that position will be equal to carry out of position
+///    `i - 1` (or to carry input, for position 0).  The above example gets split into two
+///    `adc` cells:
+///
+///    ```
+///    { y8 y7 y6 y5 } =
+///       { a7 a6 a5 } +
+///       { b7 b6 b5 } + ab4
+///
+///    { y4 y3 y2 y1 y0 } =
+///       { a3 a2 a1 a0 } +
+///       { b3 b2 b1 b0 } + ci
+///    ```
+///
+/// 2. The low bit of `a` (or `b`) is the same net as the carry input:
+///
+///    ```
+///    { y4 y3 y2 y1 y0 } =
+///       { a3 a2 a1 a0 } +
+///       { b3 b2 b1 b0 } + a0
+///    ```
+///
+///    In this case, The carry out of position `0` will always be equal to `a0`, and the sum
+///    at this position will be equal to `b0`.  The above example gets split up as follows:
+///
+///    ```
+///    { y4 y3 y2 y1 } =
+///       { a3 a2 a1 } +
+///       { b3 b2 b1 } + a0
+///
+///    y0 = b0
+///    ```
+///
+/// This optimization is comically general.  We are mostly interested in it for its useful special
+/// cases:
+///
+/// - `a + a` will get optimized into `{ a 0 }`
+/// - `a + a + ci` will get optimized into `{ a ci }`
+/// - when both operands have const LSBs, the low part is const-folded
+/// - when one operand has const-0 LSBs, and the CI is 0, the low bits of output are replaced with
+///   bits of the other operand
+/// - when one operand has const-1 LSBs, and the CI is 1, the low bits of output are replaced with
+///   bits of the other operand
+/// - when the two operands have disjoint sets of non-zero positions (eg. `{ a0 a1 0 0 } + { 0 0 b2 b3 }`,
+///   the whole cell is replaced by a buffer
+/// - when there's a stretch of zeros in both operands at the same positions, the cell gets split into two `adc`
+/// - when both operands have redundant 0 bits at MSBs, the high bits of output are replaced with 0
 fn adc_split(design: &Design, a: Value, b: Value, c: Net) -> Option<Value> {
     let mut ci = c;
     let mut result = Value::EMPTY;
@@ -248,44 +248,44 @@ fn adc_split(design: &Design, a: Value, b: Value, c: Net) -> Option<Value> {
     Some(result)
 }
 
-// Finds runs of three or more repeating pairs of bits in the inputs of an `adc` cell, shortens
-// them to just two pairs.  Mostly useful for shortening over-long `adc` cells with sign-extended
-// inputs.
-//
-// Observation: given
-//
-// ```
-// { a a } +
-// { b b } + c
-// ```
-//
-// the carry out of position 1 will always be the same as carry out of position 0:
-//
-// - if `a` and `b` are both `0`, the carry-out is `0` on both positions
-// - if `a` and `b` are both `1`, the carry-out is `1` on both positions
-// - if `a` and `b` are `0` and `1` (or the other way around), the carry-in of `c` is propagated
-//
-// Thus, if we have
-//
-// ```
-// { y3 y2 y1 y0 } =
-//     { a  a  a } +
-//     { b  b  b } + c
-// ```
-//
-// it follows that carry-in to positions 1 and 2 is the same, and so y1 = y2.  Further,
-// carry out of position 2 is also the same, allowing us to completely remove position 2
-// from the `adc` as redundant:
-//
-// ```
-// { y3 y1 y0 } =
-//     { a  a } +
-//     { b  b } + c
-// y2 = y1
-// ```
-//
-// This applies to any repetition of length ≥ 3.  While mostly applicable to trimming MSBs,
-// we recognize such repetitions anywhere within the inputs and split the `adc` cell there.
+/// Finds runs of three or more repeating pairs of bits in the inputs of an `adc` cell, shortens
+/// them to just two pairs.  Mostly useful for shortening over-long `adc` cells with sign-extended
+/// inputs.
+///
+/// Observation: given
+///
+/// ```
+/// { a a } +
+/// { b b } + c
+/// ```
+///
+/// the carry out of position 1 will always be the same as carry out of position 0:
+///
+/// - if `a` and `b` are both `0`, the carry-out is `0` on both positions
+/// - if `a` and `b` are both `1`, the carry-out is `1` on both positions
+/// - if `a` and `b` are `0` and `1` (or the other way around), the carry-in of `c` is propagated
+///
+/// Thus, if we have
+///
+/// ```
+/// { y3 y2 y1 y0 } =
+///     { a  a  a } +
+///     { b  b  b } + c
+/// ```
+///
+/// it follows that carry-in to positions 1 and 2 is the same, and so y1 = y2.  Further,
+/// carry out of position 2 is also the same, allowing us to completely remove position 2
+/// from the `adc` as redundant:
+///
+/// ```
+/// { y3 y1 y0 } =
+///     { a  a } +
+///     { b  b } + c
+/// y2 = y1
+/// ```
+///
+/// This applies to any repetition of length ≥ 3.  While mostly applicable to trimming MSBs,
+/// we recognize such repetitions anywhere within the inputs and split the `adc` cell there.
 fn adc_unsext(design: &Design, a: Value, b: Value, c: Net) -> Option<Value> {
     let mut ci = c;
     let mut offset = 0;

--- a/generic/src/simplify.rs
+++ b/generic/src/simplify.rs
@@ -224,6 +224,10 @@ fn adc_split(design: &Design, a: Value, b: Value, c: Net) -> Option<Value> {
     let mut ci = c;
     let mut result = Value::EMPTY;
     for (offset, (a_bit, b_bit)) in a.iter().zip(b.iter()).enumerate() {
+        // Note that the following cases are enough to do constant-folding as
+        // well: either the two bits are the same, or they are different.
+        // If they are different, one of them must be equal to whatever
+        // ci currently is.
         if a_bit == b_bit {
             result.extend(&design.add_adc(&a[result.len()..offset], &b[result.len()..offset], ci));
             ci = a_bit;

--- a/netlist/src/cell.rs
+++ b/netlist/src/cell.rs
@@ -77,6 +77,9 @@ pub enum Cell {
     Mux(Net, Value, Value),
     /// `a + b + ci` — add with carry.
     ///
+    /// Output is one bit wider than `a` and `b` — the most significant bit
+    /// is the carry-out.
+    ///
     /// `X`s in the input propagate only to the more significant bits, and
     /// do not affect the less significant bits.
     Adc(Value, Value, Net), // a + b + ci

--- a/netlist/src/cell.rs
+++ b/netlist/src/cell.rs
@@ -89,13 +89,33 @@ pub enum Cell {
     SLt(Value, Value),
 
     /// `a << (b * c)`. The bottom bits are filled with zeros.
+    ///
+    /// General notes for all shift cells:
+    /// - output is the same width as `a`. If you need wider output,
+    ///   zero-extend or sign-extend your input first, as appropriate.
+    /// - the shift count does not wrap. If you shift by more than
+    ///   `a.len() - 1`, you get the same result as if you made an equivalent
+    ///   sequence of 1-bit shifts (i.e. all zeros, all sign bits, or all `X`,
+    ///   as appropriate).
+    /// - shift cells are one of the few cells which *do not* expect their
+    ///   inputs to be of the same width. In fact, that is the expected case.
     Shl(Value, Value, u32),
     /// `a >> (b * c)`. The top bits are filled with zeros.
+    ///
+    /// See also [general notes above][Cell::Shl].
     UShr(Value, Value, u32),
     /// `a >> (b * c)`. The top bits are filled with copies of the top bit
     /// of the input.
+    ///
+    /// `a` must be at least one bit wide (as otherwise there would be no sign
+    /// bit to propagate, and while there wouldn't be anywhere to propagate it
+    /// *to*, it's an edge-case it doesn't make sense to bother handling).
+    ///
+    /// See also [general notes above][Cell::Shl].
     SShr(Value, Value, u32),
     /// `a >> (b * c)`. The top bits are filled with `X`.
+    ///
+    /// See also [general notes above][Cell::Shl].
     XShr(Value, Value, u32),
 
     // future possibilities: popcnt, count leading/trailing zeros, powers

--- a/netlist/src/cell.rs
+++ b/netlist/src/cell.rs
@@ -138,19 +138,39 @@ pub enum Cell {
 
     /// Design input of a given width.
     ///
-    /// If synthesizing for a specified target, an input will be replaced
-    /// with an [`IoBuffer`] and attached to a pin on the target device.
+    /// If synthesizing for a specified target, and not in out-of-context mode,
+    /// an input will be replaced with an [`IoBuffer`] and attached to a pin on
+    /// the target device.
     Input(String, usize),
     /// Design output. Attaches a name to a given value.
     ///
-    /// If synthesizing for a specified target, an output will be replaced
-    /// with an [`IoBuffer`] and attached to a pin on the target device.
+    /// If synthesizing for a specified target, and not in out-of-context mode,
+    /// an output will be replaced with an [`IoBuffer`] and attached to a pin on
+    /// the target device.
     Output(String, Value),
     /// Attaches a name to a given value for debugging.
     ///
-    /// `Name` keeps a given value alive and makes it easily available
-    /// to be poked at during simulation.
+    /// `Name` keeps a given value alive during optimization and makes it easily
+    /// available to be poked at during simulation.
+    ///
+    /// Do note that the [`unname` pass][unname], which runs during
+    /// target-dependent synthesis, replaces all `Name` cells with [`Debug`]
+    /// cells.
+    ///
+    /// [unname]: ../prjunnamed_generic/fn.unname.html
+    /// [`Debug`]: Cell::Debug
     Name(String, Value),
+    /// Tentatively attaches a name to a given value.
+    ///
+    /// `Debug` gives a name to a particular value, without insisting on keeping
+    /// it alive during optimization. This helps correlate the output of
+    /// synthesis with the corresponding input logic.
+    ///
+    /// If at any point a value is being kept alive only by a `Debug` cell,
+    /// it will be optimized out and the input to the `Debug` cell will
+    /// be replaced with `X`.
+    ///
+    /// See also: [`Name`][Cell::Name].
     Debug(String, Value),
 }
 

--- a/netlist/src/cell/decision.rs
+++ b/netlist/src/cell/decision.rs
@@ -6,6 +6,11 @@ use crate::{Const, Net, Value};
 pub struct MatchCell {
     pub value: Value,
     pub enable: Net,
+    /// Each pattern is a list of alternatives.
+    ///
+    /// Notice that `X` in a match pattern has different semantics than usual —
+    /// it signifies "match any bit", and not "replace with whatever is easier
+    /// to synthesize". This is fine, since the patterns are constants.
     pub patterns: Vec<Vec<Const>>,
 }
 
@@ -34,6 +39,7 @@ impl MatchCell {
         self.enable.visit_mut(&mut f);
     }
 }
+
 impl AssignCell {
     pub fn output_len(&self) -> usize {
         self.value.len()

--- a/netlist/src/design.rs
+++ b/netlist/src/design.rs
@@ -14,6 +14,7 @@ use crate::{
     Target, TargetCell, TargetCellPurity, TargetPrototype,
 };
 
+/// Sea of [`Cell`]s.
 #[derive(Debug, Clone)]
 pub struct Design {
     ios: BTreeMap<String, Range<u32>>,

--- a/netlist/src/lib.rs
+++ b/netlist/src/lib.rs
@@ -1,3 +1,12 @@
+//! This crate defines the IR of Project Unnamed.
+//!
+//! A [`Design`] is represented as a sea of [`Cell`]s. Each cell is identified
+//! only by a range of indices; neither cells nor the nets connecting them have
+//! names.
+//!
+//! No distinction is made between coarse and fine netlists — a single IR is
+//! used for both.
+
 mod logic;
 mod value;
 mod param;

--- a/netlist/src/logic.rs
+++ b/netlist/src/logic.rs
@@ -8,6 +8,8 @@ use std::{
 
 use crate::Net;
 
+/// Zero, one, or undef (`X`). Undef may be replaced by any other value
+/// during optimization.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Trit {
     Undef = -1,
@@ -153,6 +155,7 @@ impl std::ops::BitXor<Trit> for Trit {
     }
 }
 
+/// A constant with some bits potentially set to `X`.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Const {
     trits: Vec<Trit>,

--- a/netlist/src/value.rs
+++ b/netlist/src/value.rs
@@ -7,6 +7,10 @@ use std::{
 
 use crate::{Const, Design, Trit};
 
+/// A one-bit wide wire, identified by either the [`Cell`] that drives it,
+/// or the constant [`Trit`] it is set to.
+///
+/// [`Cell`]: crate::Cell
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Net {
     pub(crate) index: u32,
@@ -118,6 +122,10 @@ impl Display for Net {
     }
 }
 
+/// A wide bundle of [`Net`]s, possibly driven by a variety of [`Cell`]s.
+/// This is where swizzles happen.
+///
+/// [`Cell`]: crate::Cell
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Value {
     nets: Vec<Net>,
@@ -139,6 +147,7 @@ fn shift_count(val: &Const, stride: u32) -> usize {
 }
 
 impl Value {
+    /// A value of width zero.
     pub const EMPTY: Value = Value { nets: vec![] };
 
     pub fn zero(width: usize) -> Self {
@@ -153,6 +162,8 @@ impl Value {
         Self::from_iter(std::iter::repeat_n(Net::UNDEF, width))
     }
 
+    /// Creates a `Value` representing the `count`-wide output
+    /// of cell `cell_index`.
     pub(crate) fn cell(cell_index: usize, count: usize) -> Value {
         let mut nets = vec![];
         for net_index in 0..count {

--- a/netlist/src/value.rs
+++ b/netlist/src/value.rs
@@ -7,8 +7,8 @@ use std::{
 
 use crate::{Const, Design, Trit};
 
-/// A one-bit wide wire, identified by either the [`Cell`] that drives it,
-/// or the constant [`Trit`] it is set to.
+/// A one-bit wide wire, identified by either the [`Cell`] that drives it
+/// and the bit position in its output, or the constant [`Trit`] it is set to.
 ///
 /// [`Cell`]: crate::Cell
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
While not complete, this should hopefully make it easier to get an idea of what's going on in the code.

Also removes an invalid branch that I stumbled upon while documenting stuff.

Some of the comments here are effectively reverse-engineered from the code; others are paraphrasing what I read on the Matrix channel. You might want to make sure that I haven't written things that are plain wrong. In particular I feel like the comment I wrote on `Cell::{Input,Output}` might be an oversimplification.

The comments on `Cell` explain the X propagation behavior. Perhaps this would be a good usecase for doctests that consteval the relevant cells, to demonstrate the behavior in question?