### PR TITLE
[RFC] netlist: accept and print fancier value slices and repetitions.

### DIFF
--- a/netlist/src/value.rs
+++ b/netlist/src/value.rs
@@ -245,6 +245,10 @@ impl Value {
         Self::from_iter(self.iter().chain(other.into().iter()))
     }
 
+    pub fn repeat(&self, n: usize) -> Self {
+        Self::from_iter((0..n).flat_map(|_| self))
+    }
+
     pub fn slice(&self, range: impl std::ops::RangeBounds<usize>) -> Value {
         Value::from(&self[(range.start_bound().cloned(), range.end_bound().cloned())])
     }

--- a/netlist/tests/roundtrip.rs
+++ b/netlist/tests/roundtrip.rs
@@ -48,6 +48,12 @@ fn test_concat() {
     roundtrip("%0:0 = buf []\n");
     onewaytrip("%0:1 = buf [ 0 ]\n", "%0:1 = buf 0\n");
     onewaytrip("%0:2 = buf [ 1 0 ]\n", "%0:2 = buf 10\n");
+    onewaytrip("%0:1 = buf X\n%1:3 = buf [ 1 0 %0+0 ]\n", "%0:1 = buf X\n%1:3 = buf [ 10 %0 ]\n");
+    onewaytrip(
+        "%0:4 = buf XXXX\n%4:4 = buf [ %0+3 %0+2 %0+3 %0+2 ]\n",
+        "%0:4 = buf XXXX\n%4:4 = buf %0+2:2*2\n",
+    );
+    onewaytrip("%0:3 = buf 000\n%3:6 = buf [ %0:3 %0+1:2 %0+0 ]\n", "%0:3 = buf 000\n%3:6 = buf %0:3*2\n");
 }
 
 #[test]
@@ -57,6 +63,9 @@ fn test_reference() {
     roundtrip("%0:2 = buf 00\n%2:1 = buf %0+1\n");
     roundtrip("%0:2 = buf 00\n%2:2 = buf %0:2\n");
     roundtrip("%0:2 = buf 00\n%2:2 = buf [ %0+0 %0+1 ]\n");
+    roundtrip("%0:4 = buf 0000\n%4:4 = buf %0+0:2*2\n");
+    roundtrip("%0:3 = buf 000\n%3:6 = buf [ %0:3 %0+1 %0+1:2 ]\n");
+    roundtrip("%0:2 = buf 00\n%2:8 = buf %0:2*4\n");
 }
 
 #[test]
@@ -96,8 +105,8 @@ fn test_cells() {
     roundtrip("%0:2 = buf 00\n%2:3 = match %0:2 { (00 01) 10 11 }\n");
     roundtrip("%0:2 = buf 00\n%2:2 = match en=%0+1 %0+0 { 0 1 }\n");
     roundtrip("%0:16 = buf 0000000000000000\n%16:8 = match en=%0+1 %0:16 {\n  0000000000000001\n  0000000000000010\n  0000000000000100\n  0000000000001000\n  0000000000010000\n  0000000000100000\n  0000000001000000\n  0000000010000000\n}\n");
-    roundtrip("%0:4 = buf 0000\n%4:2 = assign [ %0:2 ] [ %0+2 %0+3 ]\n");
-    roundtrip("%0:4 = buf 0000\n%4:2 = assign en=%0+2 [ %0:2 ] %0+3 at=#1\n");
+    roundtrip("%0:4 = buf 0000\n%4:2 = assign %0+0:2 %0+2:2\n");
+    roundtrip("%0:4 = buf 0000\n%4:2 = assign en=%0+2 %0+0:2 %0+3 at=#1\n");
     roundtrip("%0:2 = buf 00\n%2:1 = dff %0+0 clk=%0+1\n");
     roundtrip("%0:0 = memory depth=#256 width=#16 {\n}\n");
     roundtrip("&\"purr\":1\n%0:2 = buf 00\n%2:1 = iobuf &\"purr\" o=%0+0 en=%0+1\n");


### PR DESCRIPTION
The following "expressions" are now valid as values or value concatenation chunks:

- `%123`: bit 0 of cell output `%123`; printer will only emit this if `%123` is one bit long, otherwise it will print `%123+0`, to make it easier to recognize when only a part of cell output is consumed
- `%123+2`: bit 2 of cell output `%123`
- `%123:4`: bits 0-3 of cell output `%123`; likewise, printer will only emit this if `%123` is 4 bits long, otherwise it will print `%123+0:4`
- `%123+2:4`: bits 2-5 of cell output `%123`
- `0101X1100`: a series of constant nets

Any of the above can also be repeated by appending `*<number>`:

- `%123+1*6`: six repetitions of bit 1 of `%123`
- `0*6`: equialent to `000000`

The parser will accept any kind of repetitions.  The printer will recognize them as follows:

- runs of const bits are always printed as-is, with no repetitions recognized (we could change this in the future for long single-bit runs)
- for cell output bits:
  - greedily assemble the longest possible slice, starting from LSB
  - once assembled, check whether the next bits after the recognized slice are equal to another repetition of it; if so, increase repetition count and repeat
  - move on to recognizing next slice and its repetition

This results in the following output on ambiguous cases:

- `[ %0+2 %0+2 %0+2 %0+1 %0+0 ]` (sign extension) is printed as `[ %0+2*2 %0+0:3 ]`
- `[ %0+1 %0+1 %0+0 %0+0 ]` is printed as `[ %0+1*2 %0+0*2 ]`
- `[ %0+3 %0+2 %0+3 %0+2 %0+1 %0+0 ]` is printed as `[ %0+2:2 %0+0:4 ]`
- `[ %0+3 %0+2 %0+1 %0+0 %0+1 %0+0 ]` is printed as `[ %0+2:2 %0+0:2*2 ]`