### PR TITLE
decision: Accurately check whether nets are mutually exclusive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,6 @@ version = "0.1.0"
 dependencies = [
  "prjunnamed-netlist",
  "prjunnamed-pattern",
- "union-find-rs",
 ]
 
 [[package]]
@@ -364,12 +363,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "union-find-rs"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7cf5ae6c8635588ab0aa0ddd0ba68b7586c96cd00f8d12337071219f9c885f"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ easy-smt = { git = "https://github.com/whitequark/easy-smt", branch = "buf-write
 env_logger = "0.11"
 argparse = "0.2"
 jzon = "0.12.5"
-union-find-rs = "0.2.1"
 
 [workspace.package]
 edition = "2024"

--- a/generic/Cargo.toml
+++ b/generic/Cargo.toml
@@ -12,7 +12,6 @@ doctest = false
 [dependencies]
 prjunnamed-netlist.workspace = true
 prjunnamed-pattern.workspace = true
-union-find-rs.workspace = true
 
 [features]
 trace = []


### PR DESCRIPTION
Approximating this with Union-Find isn't terribly useful, since the exact equivalent can be computed accurately.

Removes the only use of union-find-rs