### PR TITLE
Drop unnecessary `set` keyword from `set target`

### DIFF
--- a/docs/src/dev/langref.md
+++ b/docs/src/dev/langref.md
@@ -305,15 +305,15 @@ The header must be located at the beginning of the file, after any initial [whit
 ### Target specification {#target}
 
 ```
-set target <target> <option>=<value>...
+target <target> <option>=<value>...
 ```
 
 For example:
 
 ```
-set target "siliconblue"
-set target "siliconblue" "device"="ice40hx8k"
-set target "siliconblue" "device"="ice40up5k" "dsp"="off"
+target "siliconblue"
+target "siliconblue" "device"="ice40hx8k"
+target "siliconblue" "device"="ice40up5k" "dsp"="off"
 ```
 
 The target specification defines the specific device for which the netlist is intended, as well as target-specific configuration options for the flow. The `<target>`, `<option>`, and `<value>` are all [strings](#string) that are passed to the [builder function][target-builder] as-is.

--- a/netlist/src/design.rs
+++ b/netlist/src/design.rs
@@ -840,7 +840,7 @@ impl Display for Design {
         }
 
         if let Some(target) = self.target() {
-            write!(f, "{}set target ", if !diff { "" } else { unchanged })?;
+            write!(f, "{}target ", if !diff { "" } else { unchanged })?;
             self.write_string(f, target.name())?;
             for (name, value) in target.options() {
                 write!(f, " ")?;

--- a/netlist/src/parse.rs
+++ b/netlist/src/parse.rs
@@ -354,8 +354,6 @@ fn parse_target_option(t: &mut WithContext<impl Tokens<Item = char>, Context>) -
 }
 
 fn parse_target(t: &mut WithContext<impl Tokens<Item = char>, Context>) -> Option<()> {
-    parse_keyword_expect(t, "set")?;
-    parse_blank(t);
     parse_keyword_expect(t, "target")?;
     parse_blank(t);
     let name = parse_string(t)?;

--- a/netlist/tests/roundtrip.rs
+++ b/netlist/tests/roundtrip.rs
@@ -348,11 +348,11 @@ impl Target for TestTarget {
 #[test]
 fn test_target() {
     register_target("test", |options| Ok(TestTarget::new(options)));
-    roundtrip("set target \"test\" \"device\"=\"example\"\n");
+    roundtrip("target \"test\" \"device\"=\"example\"\n");
     onewaytrip(
-        "set target \"test\"\n%0:4 = target \"QUAD_IOBUF\" {\n}\n",
+        "target \"test\"\n%0:4 = target \"QUAD_IOBUF\" {\n}\n",
         concat!(
-            "set target \"test\"\n",
+            "target \"test\"\n",
             "%0:4 = target \"QUAD_IOBUF\" {\n",
             "  param \"OE_INVERT\" = 0\n",
             "  param \"PULLUP\" = 0000\n",
@@ -363,7 +363,7 @@ fn test_target() {
         ),
     );
     roundtrip(concat!(
-        "set target \"test\"\n",
+        "target \"test\"\n",
         "&\"pins\":3 = io\n",
         "%0:4 = input \"O\"\n",
         "%4:4 = target \"QUAD_IOBUF\" {\n",
@@ -375,7 +375,7 @@ fn test_target() {
         "}\n"
     ));
     roundtrip(concat!(
-        "set target \"test\"\n",
+        "target \"test\"\n",
         "%0:1 = input \"A\"\n",
         "%1:1 = input \"B\"\n",
         "; drives \"co\"+0\n",
@@ -390,7 +390,7 @@ fn test_target() {
         "%7:0 = output \"co\" %5\n",
     ));
     roundtrip(concat!(
-        "set target \"test\"\n",
+        "target \"test\"\n",
         "!0 = source \"top.py\" (#1 #2) (#3 #4)\n",
         "%0:1 = input \"A\"\n",
         "; source file://top.py#2\n",
@@ -399,7 +399,7 @@ fn test_target() {
         "}\n"
     ));
     roundtrip(concat!(
-        "set target \"test\"\n",
+        "target \"test\"\n",
         "!0 = source \"top.py\" (#1 #2) (#3 #4)\n",
         "%0:1 = input \"A\"\n",
         "%1:1 = input \"B\"\n",


### PR DESCRIPTION
This was originally added in context of moving the cell identifier in the declaration of target cells to their outputs, but as the syntax now always has a cell identifier in the front (whether or not a concise form is used) this isn't necessary any more.