### PR TITLE
Implement Graphviz output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /target
 /build
 *.uir
+*.dot
+*.svg
 
 # llvm-cov
 *.profraw

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,7 @@ dependencies = [
  "argparse",
  "env_logger",
  "prjunnamed-generic",
+ "prjunnamed-graphviz",
  "prjunnamed-netlist",
  "prjunnamed-pattern",
  "prjunnamed-siliconblue",
@@ -183,6 +184,13 @@ dependencies = [
  "prjunnamed-netlist",
  "prjunnamed-pattern",
  "union-find-rs",
+]
+
+[[package]]
+name = "prjunnamed-graphviz"
+version = "0.1.0"
+dependencies = [
+ "prjunnamed-netlist",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "memory",
     "yosys_json",
     "siliconblue",
+    "graphviz",
     "cli",
 ]
 
@@ -19,6 +20,7 @@ prjunnamed-lut.path = "lut"
 prjunnamed-memory.path = "memory"
 prjunnamed-yosys_json.path = "yosys_json"
 prjunnamed-siliconblue.path = "siliconblue"
+prjunnamed-graphviz.path = "graphviz"
 indexmap = "2.7.1"
 yap = "0.12.0"
 # easy-smt = "0.2.7"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,7 @@ prjunnamed-pattern.workspace = true
 prjunnamed-generic.workspace = true
 prjunnamed-yosys_json.workspace = true
 prjunnamed-siliconblue.workspace = true
+prjunnamed-graphviz.workspace = true
 argparse.workspace = true
 env_logger.workspace = true
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -35,6 +35,7 @@ fn read_input(target: Option<Arc<dyn Target>>, name: String) -> Result<Design, B
 enum OutputType {
     YosysJson,
     UIR,
+    GraphvizDot,
 }
 
 impl OutputType {
@@ -43,6 +44,8 @@ impl OutputType {
             Self::UIR
         } else if name.ends_with(".json") {
             Self::YosysJson
+        } else if name.ends_with(".dot") {
+            Self::GraphvizDot
         } else {
             panic!("don't know what to do with output {name:?}");
         }
@@ -72,6 +75,9 @@ fn write_output(mut design: Design, name: String, export: bool) -> Result<(), Bo
         OutputType::YosysJson => {
             let designs = BTreeMap::from([("top".to_owned(), design)]);
             prjunnamed_yosys_json::export(&mut output, designs)?;
+        }
+        OutputType::GraphvizDot => {
+            prjunnamed_graphviz::describe(&mut output, &design)?;
         }
     }
 

--- a/graphviz/Cargo.toml
+++ b/graphviz/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "prjunnamed-graphviz"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lib]
+doctest = false
+
+[dependencies]
+prjunnamed-netlist.workspace = true

--- a/graphviz/src/lib.rs
+++ b/graphviz/src/lib.rs
@@ -380,6 +380,9 @@ pub fn describe<'a>(writer: &mut impl io::Write, design: &'a Design) -> io::Resu
             }
             _ => {
                 let label = design.display_cell(cell).to_string();
+                // this sucks but braces are special to Graphviz.
+                // yes, even in strings
+                let label = label.replace("{", "(").replace("}", ")");
                 let mut node = Node::new(cell, label);
 
                 cell.visit(|net| {

--- a/graphviz/src/lib.rs
+++ b/graphviz/src/lib.rs
@@ -1,0 +1,43 @@
+use std::collections::BTreeSet;
+use std::io::Write;
+use std::io;
+use std::fmt;
+use prjunnamed_netlist::Design;
+
+struct Node {
+    index: usize,
+    label: String,
+}
+
+impl fmt::Display for Node {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "node_{} [shape=rect label=\"{}\"];", self.index, self.label.escape_default())
+    }
+}
+
+pub fn describe(writer: &mut impl Write, design: &Design) -> io::Result<()> {
+    writeln!(writer, "digraph {{")?;
+    writeln!(writer, "  rankdir=LR;")?;
+    for cell in design.iter_cells_topo() {
+        let index = cell.debug_index();
+        let node = Node {
+            index,
+            label: design.display_cell(cell).to_string(),
+        };
+
+        writeln!(writer, "  {node}")?;
+
+        let mut inputs = BTreeSet::new();
+        cell.visit(|net| {
+            if let Ok((cell, _index)) = design.find_cell(net) {
+                inputs.insert(cell.debug_index());
+            }
+        });
+
+        for input in inputs {
+            writeln!(writer, "  node_{input} -> node_{index};")?;
+        }
+    }
+
+    writeln!(writer, "}}")
+}

--- a/graphviz/src/lib.rs
+++ b/graphviz/src/lib.rs
@@ -159,7 +159,9 @@ impl<'a> Context<'a> {
                 for input in iter {
                     write!(&mut label, ", {:?}", input).unwrap();
                 }
-                write!(&mut label, ")").unwrap();
+                writeln!(&mut label, ")").unwrap();
+            } else if !arg.ends_with('\n') {
+                writeln!(&mut label).unwrap();
             }
         }
 

--- a/graphviz/src/lib.rs
+++ b/graphviz/src/lib.rs
@@ -1,42 +1,153 @@
 use std::collections::BTreeSet;
-use std::io::Write;
+use std::fmt::{self, Write};
 use std::io;
-use std::fmt;
-use prjunnamed_netlist::Design;
+use prjunnamed_netlist::{Cell, CellRef, Design, Net, Value};
 
-struct Node {
-    index: usize,
-    label: String,
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct NodeInput<'a> {
+    from_cell: CellRef<'a>,
+    to_arg: Option<usize>,
 }
 
-impl fmt::Display for Node {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "node_{} [shape=rect label=\"{}\"];", self.index, self.label.escape_default())
+impl<'a> From<CellRef<'a>> for NodeInput<'a> {
+    fn from(cell: CellRef<'a>) -> Self {
+        Self {
+            from_cell: cell,
+            to_arg: None,
+        }
     }
 }
 
-pub fn describe(writer: &mut impl Write, design: &Design) -> io::Result<()> {
-    writeln!(writer, "digraph {{")?;
-    writeln!(writer, "  rankdir=LR;")?;
-    for cell in design.iter_cells_topo() {
-        let index = cell.debug_index();
-        let node = Node {
+struct Node<'a> {
+    design: &'a Design,
+    index: usize,
+    label: String,
+    args: Vec<String>,
+    inputs: BTreeSet<NodeInput<'a>>,
+}
+
+impl fmt::Display for Node<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut label = format!("<out> {}", self.label);
+        for (i, arg) in self.args.iter().enumerate() {
+            write!(&mut label, " | <arg{i}> {arg}")?;
+        }
+
+        writeln!(f, "  node_{} [shape=record label=\"{}\"];", self.index, label.escape_default())?;
+
+        for input in &self.inputs {
+            let input_index = input.from_cell.debug_index();
+            let port = match input.to_arg {
+                Some(n) => format!("arg{n}"),
+                None => format!("out"),
+            };
+            writeln!(f, "  node_{}:out -> node_{}:{};", input_index, self.index, port)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Node<'a> {
+    fn new(design: &'a Design, index: usize, label: String) -> Self {
+        Self {
+            design,
             index,
-            label: design.display_cell(cell).to_string(),
-        };
+            label,
+            args: Vec::new(),
+            inputs: BTreeSet::new(),
+        }
+    }
 
-        writeln!(writer, "  {node}")?;
+    fn from_name(cell: CellRef<'a>, name: &str) -> Self {
+        let index = cell.debug_index();
+        let width = cell.output_len();
+        let label = format!("%{index}:{width} = {name}");
+        Self::new(cell.design(), index, label)
+    }
 
-        let mut inputs = BTreeSet::new();
-        cell.visit(|net| {
-            if let Ok((cell, _index)) = design.find_cell(net) {
-                inputs.insert(cell.debug_index());
+    fn add_input(&mut self, input: impl Into<NodeInput<'a>>) {
+        self.inputs.insert(input.into());
+    }
+
+    fn arg(mut self, input: impl ToString) -> Self {
+        self.args.push(input.to_string());
+        self
+    }
+
+    fn net(mut self, input: &Net) -> Self {
+        let to_arg = Some(self.args.len());
+        if let Ok((cell, _)) = self.design.find_cell(*input) {
+            self.add_input(NodeInput {
+                from_cell: cell,
+                to_arg,
+            });
+        }
+
+        let s = self.design.display_net(input).to_string();
+        self.arg(s)
+    }
+
+    fn value(mut self, input: &Value) -> Self {
+        let to_arg = Some(self.args.len());
+        input.visit(|net| {
+            if let Ok((cell, _)) = self.design.find_cell(net) {
+                self.add_input(NodeInput {
+                    from_cell: cell,
+                    to_arg,
+                });
             }
         });
 
-        for input in inputs {
-            writeln!(writer, "  node_{input} -> node_{index};")?;
-        }
+        let s = self.design.display_value(input).to_string();
+        self.arg(s)
+    }
+}
+
+pub fn describe(writer: &mut impl io::Write, design: &Design) -> io::Result<()> {
+    writeln!(writer, "digraph {{")?;
+    writeln!(writer, "  rankdir=LR;")?;
+    writeln!(writer, "  node [fontname=\"monospace\"];")?;
+    for cell in design.iter_cells_topo() {
+        let node = match &*cell.get() {
+            Cell::Name(_, _) | Cell::Debug(_, _) => continue,
+            Cell::Buf(a) => Node::from_name(cell, "buf").value(a),
+            Cell::Not(a) => Node::from_name(cell, "not").value(a),
+            Cell::And(a, b) => Node::from_name(cell, "and").value(a).value(b),
+            Cell::Or(a, b) => Node::from_name(cell, "or").value(a).value(b),
+            Cell::Xor(a, b) => Node::from_name(cell, "xor").value(a).value(b),
+            Cell::Mux(a, b, c) => Node::from_name(cell, "mux").net(a).value(b).value(c),
+            Cell::Adc(a, b, c) => Node::from_name(cell, "adc").value(a).value(b).net(c),
+            Cell::Eq(a, b) => Node::from_name(cell, "eq").value(a).value(b),
+            Cell::ULt(a, b) => Node::from_name(cell, "ult").value(a).value(b),
+            Cell::SLt(a, b) => Node::from_name(cell, "slt").value(a).value(b),
+            Cell::Shl(a, b, c) => Node::from_name(cell, "shl").value(a).value(b).arg(c),
+            Cell::UShr(a, b, c) => Node::from_name(cell, "ushr").value(a).value(b).arg(c),
+            Cell::SShr(a, b, c) => Node::from_name(cell, "sshr").value(a).value(b).arg(c),
+            Cell::XShr(a, b, c) => Node::from_name(cell, "xshr").value(a).value(b).arg(c),
+            Cell::Mul(a, b) => Node::from_name(cell, "mul").value(a).value(b),
+            Cell::UDiv(a, b) => Node::from_name(cell, "udiv").value(a).value(b),
+            Cell::UMod(a, b) => Node::from_name(cell, "umod").value(a).value(b),
+            Cell::SDivTrunc(a, b) => Node::from_name(cell, "sdiv_trunc").value(a).value(b),
+            Cell::SDivFloor(a, b) => Node::from_name(cell, "sdiv_floor").value(a).value(b),
+            Cell::SModTrunc(a, b) => Node::from_name(cell, "smod_trunc").value(a).value(b),
+            Cell::SModFloor(a, b) => Node::from_name(cell, "smod_floor").value(a).value(b),
+            _ => {
+                let index = cell.debug_index();
+                let label = design.display_cell(cell).to_string();
+                let mut node = Node::new(design, index, label);
+
+                cell.visit(|net| {
+                    if let Ok((cell, _index)) = design.find_cell(net) {
+                        node.add_input(cell);
+                    }
+                });
+
+                node
+            }
+        };
+
+        writeln!(writer, "  {node}")?;
     }
 
     writeln!(writer, "}}")

--- a/graphviz/src/lib.rs
+++ b/graphviz/src/lib.rs
@@ -138,9 +138,11 @@ impl<'a> Context<'a> {
     }
 
     fn print_node(&self, writer: &mut impl io::Write, node: &Node<'_>) -> io::Result<()> {
+        let force = node.inputs.len() == 1;
+
         let mut clarify = vec![BTreeSet::new(); node.args.len()];
         for input in &node.inputs {
-            if self.high_fanout(input.from_cell).is_some() {
+            if !force && self.high_fanout(input.from_cell).is_some() {
                 let Some(name) = self.best_name.get(&input.from_cell) else { continue };
                 let Some(arg) = input.to_arg else { continue };
                 clarify[arg].insert(name);
@@ -166,7 +168,7 @@ impl<'a> Context<'a> {
         writeln!(writer, "  node_{index} [shape=record label=\"{label}\"];")?;
 
         for input in &node.inputs {
-            if self.high_fanout(input.from_cell).is_some() {
+            if !force && self.high_fanout(input.from_cell).is_some() {
                 continue;
             }
 

--- a/graphviz/src/lib.rs
+++ b/graphviz/src/lib.rs
@@ -181,6 +181,11 @@ impl<'a> Context<'a> {
             writeln!(writer, "  node_{input_index}:out -> node_{index}:{port};")?;
         }
 
+        if let Some(fanout) = self.high_fanout(node.cell) {
+            writeln!(writer, "  stub_{index} [label=\"{fanout} other uses...\"];")?;
+            writeln!(writer, "  node_{index}:out -> stub_{index};")?;
+        }
+
         Ok(())
     }
 }

--- a/graphviz/src/lib.rs
+++ b/graphviz/src/lib.rs
@@ -4,12 +4,12 @@ use std::io;
 use prjunnamed_netlist::{Cell, CellRef, ControlNet, Design, Net, Value};
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct NodeInput<'a> {
+struct Edge<'a> {
     from_cell: CellRef<'a>,
     to_arg: Option<usize>,
 }
 
-impl<'a> From<CellRef<'a>> for NodeInput<'a> {
+impl<'a> From<CellRef<'a>> for Edge<'a> {
     fn from(cell: CellRef<'a>) -> Self {
         Self {
             from_cell: cell,
@@ -23,7 +23,7 @@ struct Node<'a> {
     index: usize,
     label: String,
     args: Vec<String>,
-    inputs: BTreeSet<NodeInput<'a>>,
+    inputs: BTreeSet<Edge<'a>>,
 }
 
 impl fmt::Display for Node<'_> {
@@ -66,7 +66,7 @@ impl<'a> Node<'a> {
         Self::new(cell.design(), index, label)
     }
 
-    fn add_input(&mut self, input: impl Into<NodeInput<'a>>) {
+    fn add_input(&mut self, input: impl Into<Edge<'a>>) {
         self.inputs.insert(input.into());
     }
 
@@ -78,7 +78,7 @@ impl<'a> Node<'a> {
     fn net(mut self, input: &Net) -> Self {
         let to_arg = Some(self.args.len());
         if let Ok((cell, _)) = self.design.find_cell(*input) {
-            self.add_input(NodeInput {
+            self.add_input(Edge {
                 from_cell: cell,
                 to_arg,
             });
@@ -92,7 +92,7 @@ impl<'a> Node<'a> {
         let to_arg = Some(self.args.len());
         input.visit(|net| {
             if let Ok((cell, _)) = self.design.find_cell(net) {
-                self.add_input(NodeInput {
+                self.add_input(Edge {
                     from_cell: cell,
                     to_arg,
                 });
@@ -106,7 +106,7 @@ impl<'a> Node<'a> {
     fn control(mut self, name: &str, input: ControlNet, extra: Option<String>) -> Self {
         let to_arg = Some(self.args.len());
         if let Ok((cell, _)) = self.design.find_cell(input.net()) {
-            self.add_input(NodeInput {
+            self.add_input(Edge {
                 from_cell: cell,
                 to_arg,
             });

--- a/graphviz/src/lib.rs
+++ b/graphviz/src/lib.rs
@@ -182,7 +182,11 @@ impl<'a> Context<'a> {
         }
 
         if let Some(fanout) = self.high_fanout(node.cell) {
-            writeln!(writer, "  stub_{index} [label=\"{fanout} other uses...\"];")?;
+            let mut label = format!("{fanout} uses");
+            if let Some(name) = self.best_name.get(&node.cell) {
+                write!(&mut label, "\n{name:?}").unwrap();
+            }
+            writeln!(writer, "  stub_{index} [label=\"{}\"];", label.escape_default())?;
             writeln!(writer, "  node_{index}:out -> stub_{index};")?;
         }
 

--- a/graphviz/src/lib.rs
+++ b/graphviz/src/lib.rs
@@ -3,8 +3,6 @@ use std::fmt::Write;
 use std::io;
 use prjunnamed_netlist::{Cell, CellRef, ControlNet, Design, Net, Value};
 
-const FANOUT_THRESHOLD: usize = 10;
-
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct Edge<'a> {
     from_cell: CellRef<'a>,
@@ -116,7 +114,13 @@ impl<'a> Context<'a> {
 
     fn high_fanout(&self, cell: CellRef<'_>) -> Option<usize> {
         let fanout = self.fanout.get(&cell).map(BTreeSet::len).unwrap_or(0);
-        if fanout >= FANOUT_THRESHOLD {
+        let threshold = if self.best_name.contains_key(&cell) {
+            5
+        } else {
+            10
+        };
+
+        if fanout >= threshold {
             Some(fanout)
         } else {
             None

--- a/netlist/src/design.rs
+++ b/netlist/src/design.rs
@@ -846,12 +846,12 @@ impl Display for Design {
 
         if let Some(target) = self.target() {
             write!(f, "{}target ", if !diff { "" } else { unchanged })?;
-            self.write_string(f, target.name())?;
+            Design::write_string(f, target.name())?;
             for (name, value) in target.options() {
                 write!(f, " ")?;
-                self.write_string(f, &name)?;
+                Design::write_string(f, &name)?;
                 write!(f, "=")?;
-                self.write_string(f, &value)?;
+                Design::write_string(f, &value)?;
             }
             writeln!(f)?;
         }
@@ -874,14 +874,14 @@ impl Display for Design {
                 }
                 MetaItem::Source { file, start, end } => {
                     write!(f, "source ")?;
-                    self.write_string(f, &file.get())?;
+                    Design::write_string(f, &file.get())?;
                     write!(f, " (#{} #{}) (#{} #{})", start.line, start.column, end.line, end.column)?;
                 }
                 MetaItem::NamedScope { name: _, source, parent }
                 | MetaItem::IndexedScope { index: _, source, parent } => {
                     write!(f, "scope ")?;
                     match item {
-                        MetaItem::NamedScope { name, .. } => self.write_string(f, &name.get())?,
+                        MetaItem::NamedScope { name, .. } => Design::write_string(f, &name.get())?,
                         MetaItem::IndexedScope { index, .. } => write!(f, "#{index}")?,
                         _ => unreachable!(),
                     }
@@ -894,14 +894,13 @@ impl Display for Design {
                 }
                 MetaItem::Ident { name, scope } => {
                     write!(f, "ident ")?;
-                    self.write_string(f, &name.get())?;
+                    Design::write_string(f, &name.get())?;
                     write!(f, " in={}", scope.index())?;
                 }
                 MetaItem::Attr { name, value } => {
                     write!(f, "attr ")?;
-                    self.write_string(f, &name.get())?;
-                    write!(f, " ")?;
-                    self.write_param_value(f, &value)?;
+                    Design::write_string(f, &name.get())?;
+                    write!(f, " {value}")?;
                 }
             }
             writeln!(f)?;
@@ -909,12 +908,12 @@ impl Display for Design {
 
         for (name, io_value) in self.iter_ios() {
             write!(f, "{}&", if !diff { "" } else { unchanged })?;
-            self.write_string(f, name)?;
+            Design::write_string(f, name)?;
             writeln!(f, ":{} = io", io_value.len())?;
         }
         for (name, io_value) in &changes.added_ios {
             write!(f, "{added}&")?;
-            self.write_string(f, name)?;
+            Design::write_string(f, name)?;
             writeln!(f, ":{} = io", io_value.len())?;
         }
 
@@ -950,7 +949,7 @@ impl Display for Design {
                 for index in (index..index + cell.output_len()).rev() {
                     if let Some((name, offset)) = net_names.get(&Net::from_cell_index(index)) {
                         write!(f, "{comment}drives ")?;
-                        self.write_string(f, &*name)?;
+                        Design::write_string(f, &*name)?;
                         writeln!(f, "+{offset}")?;
                     }
                 }

--- a/netlist/src/design.rs
+++ b/netlist/src/design.rs
@@ -467,14 +467,19 @@ impl<'a> CellRef<'a> {
         changes.unalived_cells.insert(self.index);
     }
 
-    // Returns the same index as the one used by `Display` implementation. There is intentionally no way to retrieve
-    // a cell by its index.
+    /// Returns the same index as the one used by `Display` implementation. There is intentionally no way to retrieve
+    /// a cell by its index.
     pub fn debug_index(&self) -> usize {
         self.index
     }
 
     pub(crate) fn metadata_index(&self) -> MetaItemIndex {
         self.design.cells[self.index].meta
+    }
+
+    /// Returns a reference to the underlying [`Design`].
+    pub fn design(self) -> &'a Design {
+        self.design
     }
 }
 

--- a/netlist/src/param.rs
+++ b/netlist/src/param.rs
@@ -1,4 +1,5 @@
-use crate::{Const, Trit};
+use crate::{Const, Design, Trit};
+use std::fmt::Display;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ParamValue {
@@ -47,5 +48,16 @@ impl From<String> for ParamValue {
 impl From<&str> for ParamValue {
     fn from(value: &str) -> Self {
         Self::String(value.into())
+    }
+}
+
+impl Display for ParamValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParamValue::Const(value) => write!(f, "{value}"),
+            ParamValue::Int(value) => write!(f, "#{value}"),
+            ParamValue::Float(_value) => unimplemented!("float parameter"),
+            ParamValue::String(value) => Design::write_string(f, &value),
+        }
     }
 }

--- a/netlist/src/print.rs
+++ b/netlist/src/print.rs
@@ -634,7 +634,6 @@ impl Design {
 
     pub fn display_cell<'a>(&'a self, cell_ref: CellRef<'a>) -> impl Display + 'a {
         DisplayFn(self, move |design: &Design, f| {
-            write!(f, "%{}:{} = ", cell_ref.debug_index(), cell_ref.output_len())?;
             design.write_cell(f, "", cell_ref.debug_index(), &*cell_ref.get(), cell_ref.metadata().index())
         })
     }

--- a/netlist/src/print.rs
+++ b/netlist/src/print.rs
@@ -139,6 +139,13 @@ impl Design {
         }
     }
 
+    pub(crate) fn write_control_net(&self, f: &mut std::fmt::Formatter, control_net: ControlNet) -> std::fmt::Result {
+        if control_net.is_negative() {
+            write!(f, "!")?;
+        };
+        self.write_net(f, control_net.net())
+    }
+
     pub(crate) fn write_value(&self, f: &mut std::fmt::Formatter, value: &Value) -> std::fmt::Result {
         enum Chunk {
             Slice { cell_index: usize, offset: usize, width: usize, repeat: usize },
@@ -266,16 +273,9 @@ impl Design {
             }
         };
 
-        let write_control_net = |f: &mut std::fmt::Formatter, control_net: ControlNet| -> std::fmt::Result {
-            if control_net.is_negative() {
-                write!(f, "!")?;
-            };
-            self.write_net(f, control_net.net())
-        };
-
         let write_control = |f: &mut std::fmt::Formatter, name: &str, control_net: ControlNet| -> std::fmt::Result {
             write!(f, "{}=", name)?;
-            write_control_net(f, control_net)
+            self.write_control_net(f, control_net)
         };
 
         let write_common = |f: &mut std::fmt::Formatter, name: &str, args: &[&Value]| -> std::fmt::Result {
@@ -625,6 +625,11 @@ impl Design {
     pub fn display_net(&self, net: impl Into<Net>) -> impl Display + '_ {
         let net = net.into();
         DisplayFn(self, move |design: &Design, f| design.write_net(f, net))
+    }
+
+    pub fn display_control_net(&self, net: impl Into<ControlNet>) -> impl Display + '_ {
+        let net = net.into();
+        DisplayFn(self, move |design: &Design, f| design.write_control_net(f, net))
     }
 
     pub fn display_value<'a, 'b: 'a>(&'a self, value: impl Into<Cow<'b, Value>>) -> impl Display + 'a {


### PR DESCRIPTION
This PR adds a Graphviz-based UIR visualizer, available by specifying a `.dot` or `.svg` output extension.

Here's an example output generated by the visualizer – the Boneless-CPU ALSRU:
![alsru](https://github.com/user-attachments/assets/c7456189-0f83-4f0b-ab2e-0126f9239b33)

To avoid Graphviz hell, the edges going out of high-fanout nodes are hidden, unless the high-fanout node is the only input of another node. This seems to be working well – the graph is readable enough to suggest optimizations like #63.

Future work:
- concatenations could further subdivide the node, so that edges can point into a specific part of a concatenation
- multi-output cells are currently treated as single-output
- a sufficiently smart refactoring could avoid code duplication between `netlist::print` and `graphviz`