### PR TITLE
CI: push site to `pages` branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Publish documentation
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:
+          branch: pages
           folder: docs/out/
 
   cargo-deny:


### PR DESCRIPTION
For migration to https://grebedoc.dev.